### PR TITLE
Implement Autoloader

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!class_exists('mPay24\Autoloader')) {
+    require __DIR__ . '/lib/Autoloader.php';
+}
+
+mPay24\Autoloader::register();

--- a/lib/Autoloader.php
+++ b/lib/Autoloader.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace mPay24;
+
+class Autoloader
+{
+    private static $registered = false;
+
+    static public function register()
+    {
+        if (self::$registered === true) {
+            return;
+        }
+
+        spl_autoload_register(array(__CLASS__, 'autoload'));
+
+        self::$registered = true;
+    }
+
+    static public function autoload($class)
+    {
+        if (0 === strpos($class, 'mPay24\\')) {
+
+            $fileName = __DIR__ . strtr(substr($class, 6), '\\', '/') . '.php';
+            if (file_exists($fileName)) {
+                require_once $fileName;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Having a own Autoloader makes it possible to have a way for Developers that want implement mPay24 without composer or a alternative Package System.

User can download the mpay24-php branch as Standalone,
and only have to include one 1 require line:

```
require('./mpay24-php/bootstrap.php');
use mPay24\MPAY24;

$mpay24 = new MPAY24();

```