### PR TITLE
Make createAt more flexiblle to use

### DIFF
--- a/src/Responses/AbstractResponse.php
+++ b/src/Responses/AbstractResponse.php
@@ -97,13 +97,13 @@ abstract class AbstractResponse
     }
 
     /**
-     * @param $element
+     * Dumps the internal XML tree back into a string
      *
-     * @return \DOMElement
+     * @return string
      */
-    protected function getBody($element)
+	public function getXml()
     {
-        return $this->responseAsDom->getElementsByTagNameNS(self::NAME_SPACE, $element)->item(0);
+        return $this->responseAsDom->saveXML();
     }
 
     /**
@@ -172,4 +172,14 @@ abstract class AbstractResponse
     {
         return $this->createdAt;
     }
+
+	/**
+	 * @param $element
+	 *
+	 * @return \DOMElement
+	 */
+	protected function getBody($element)
+	{
+		return $this->responseAsDom->getElementsByTagNameNS(self::NAME_SPACE, $element)->item(0);
+	}
 }

--- a/src/Responses/AbstractResponse.php
+++ b/src/Responses/AbstractResponse.php
@@ -41,7 +41,7 @@ abstract class AbstractResponse
     protected $returnCode;
 
     /**
-     * @var \DateTime
+     * @var int
      */
     protected $createdAt;
 
@@ -93,7 +93,7 @@ abstract class AbstractResponse
             $this->returnCode = "The response is empty! Probably your request to mPAY24 was not sent! Please see your server log for more information!";
         }
 
-        $this->createdAt = new \DateTime('now');
+        $this->createdAt = time();
     }
 
     /**
@@ -166,7 +166,7 @@ abstract class AbstractResponse
     }
 
     /**
-     * @return \DateTime
+     * @return int
      */
     public function getCreatedAt()
     {


### PR DESCRIPTION
@tobiaslins as we discuses in the last PR https://github.com/mpay24/mpay24-php/pull/48 a time stamp is more flexible compared to an Object if we don't know how users will need it. @netbull need it as DateTime Object but maybe someone else need it differnert. With a time Stamp you can also do simple math like:
```php
$valid = 60 * 15 // e.g. 15 Minutes valid

if($responseWithToken->getCreatedAt() + $valid > time()){
    // Token is still valid
} else {
    // Token is invalid
}
```
And you can use it es base for any kind of Object including DateTime or Carbon (very common in Laravel)
```php
$dateTimeObject = new \DateTime('@' . $response->getCreatedAt());
$carbonObject   = Carbon::createFromTimestamp($response->getCreatedAt());
```
