### PR TITLE
Make cacert.pem configurable in config file

### DIFF
--- a/config.php
+++ b/config.php
@@ -15,3 +15,5 @@ define('MPAY24_FLEX_LINK_TEST_SYSTEM', true);
 define('MPAY24_LOG_FILE', 'mpay24.log');
 define('MPAY24_LOG_PATH', dirname(__FILE__) . '/logs');
 define('MPAY24_CURL_LOG_FILE', 'curllog.log');
+define('MPAY24_CA_CERT_PATH', dirname(__FILE__) . '/src/bin/');
+define('MPAY24_CA_CERT_FILE_NAME', 'cacert.pem');

--- a/src/Mpay24.php
+++ b/src/Mpay24.php
@@ -35,7 +35,7 @@ class Mpay24
 
         $this->mpay24Sdk = new Mpay24Sdk($config);
 
-        $this->mpay24Sdk->checkRequirements(true, true, false);
+        $this->mpay24Sdk->checkRequirements(true, true);
     }
 
     /**

--- a/src/Mpay24.php
+++ b/src/Mpay24.php
@@ -39,13 +39,6 @@ class Mpay24
     }
 
     /**
-     * @param string $caInfoPath
-     */
-    public function setCaInfoPath($caInfoPath) {
-        $this->mpay24Sdk->setCaInfoPath($caInfoPath);
-    }
-
-    /**
      * Get a list which includes all the payment methods (activated by mPAY24) for your mechant ID
      *
      * @return Responses\ListPaymentMethodsResponse
@@ -273,7 +266,7 @@ class Mpay24
      *
      * @param string $paymentType The payment type which will be used for the payment (CC or TOKEN)
      * @param        $customerId
-     * @param        $paymentData
+     * @param        $payment
      * @param        $additional
      *
      * @return Responses\CreateCustomerResponse

--- a/src/Mpay24Config.php
+++ b/src/Mpay24Config.php
@@ -113,6 +113,16 @@ class Mpay24Config
      */
     protected $log_path;
 
+	/**
+	 * @var string
+	 */
+	protected $ca_cert_path;
+
+	/**
+	 * @var string
+	 */
+	protected $ca_cert_file_name;
+
     public function __construct()
     {
         $args = func_get_args();
@@ -120,6 +130,10 @@ class Mpay24Config
         if (isset($args[0]) && is_array($args[0])) {
             $args = $args[0];
         }
+
+        // define if not defined, for backwards compatibility
+	    defined('MPAY24_CA_CERT_PATH') or define('MPAY24_CA_CERT_PATH', dirname(__FILE__) . '/bin/');
+	    defined('MPAY24_CA_CERT_FILE_NAME') or define('MPAY24_CA_CERT_FILE_NAME', 'cacert.pem');
 
         $merchantID         = (isset($args[0]) ? $args[0] : MPAY24_MERCHANT_ID);
         $soapPassword       = (isset($args[1]) ? $args[1] : MPAY24_SOAP_PASS);
@@ -137,6 +151,8 @@ class Mpay24Config
         $log_file           = (isset($args[13]) ? $args[13] : MPAY24_LOG_FILE);
         $log_path           = (isset($args[14]) ? $args[14] : MPAY24_LOG_PATH);
         $curl_log_file      = (isset($args[15]) ? $args[15] : MPAY24_CURL_LOG_FILE);
+        $ca_cert_path       = (isset($args[16]) ? $args[16] : MPAY24_CA_CERT_PATH);
+        $ca_cert_file_name  = (isset($args[17]) ? $args[17] : MPAY24_CA_CERT_FILE_NAME);
 
         $this->useTestSystem($testSystem);
         $this->setMerchantID($merchantID);
@@ -154,6 +170,8 @@ class Mpay24Config
         $this->setLogFile($log_file);
         $this->setLogPath($log_path);
         $this->setCurlLogFile($curl_log_file);
+        $this->setCaCertPath($ca_cert_path);
+        $this->setCaCertFileName($ca_cert_file_name);
     }
 
     /**
@@ -433,4 +451,36 @@ class Mpay24Config
     {
         $this->curl_log_file = ltrim($curl_log_file, "\\");
     }
+
+	/**
+	 * @return string
+	 */
+	public function getCaCertPath()
+	{
+		return $this->ca_cert_path;
+	}
+
+	/**
+	 * @param string $ca_cert_path
+	 */
+	public function setCaCertPath($ca_cert_path)
+	{
+		$this->ca_cert_path = $ca_cert_path;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCaCertFileName()
+	{
+		return $this->ca_cert_file_name;
+	}
+
+	/**
+	 * @param string $ca_cert_file_name
+	 */
+	public function setCaCertFileName($ca_cert_file_name)
+	{
+		$this->ca_cert_file_name = $ca_cert_file_name;
+	}
 }

--- a/src/Mpay24FlexLink.php
+++ b/src/Mpay24FlexLink.php
@@ -53,7 +53,7 @@ class Mpay24FlexLink
             $this->mpay24Sdk = new Mpay24Sdk($config);
         }
 
-        $this->mpay24Sdk->checkRequirements(false, false, true);
+        $this->mpay24Sdk->checkRequirements(false, false);
     }
 
     /**

--- a/src/Mpay24Sdk.php
+++ b/src/Mpay24Sdk.php
@@ -101,11 +101,6 @@ class Mpay24Sdk
      */
     protected $config;
 
-    /**
-     * @var string
-     */
-    protected $caInfoPath = __DIR__ .  '/bin/';
-
     public function __construct(Mpay24Config &$config = null)
     {
         if (is_null($config)) {
@@ -642,13 +637,6 @@ class Mpay24Sdk
     }
 
     /**
-     * @param string $caInfoPath
-     */
-    public function setCaInfoPath($caInfoPath) {
-        $this->caInfoPath = $caInfoPath;
-    }
-
-    /**
      * Create a curl request and send the created SOAP XML
      */
     protected function send()
@@ -672,7 +660,7 @@ class Mpay24Sdk
         }
 
         try {
-            curl_setopt($ch, CURLOPT_CAINFO, $this->caInfoPath . 'cacert.pem');
+            curl_setopt($ch, CURLOPT_CAINFO, $this->config->getCaCertPath() . $this->config->getCaCertFileName());
 
             if ($this->config->getProxyHost()) {
                 curl_setopt($ch, CURLOPT_PROXY, $this->config->getProxyHost() . ':' . $this->config->getProxyPort());
@@ -702,7 +690,7 @@ class Mpay24Sdk
             echo $dieMSG;
         }
 
-        if ($this->config->isEnableCurlLog()) {
+        if (isset($fh) && $this->config->isEnableCurlLog()) {
             fclose($fh);
         }
     }


### PR DESCRIPTION
Replacement for #63
Using the config.php file and Mpay24Config Class to set cacert.pem path and file. 
Make it backwards compatible with older config.php files, that do not have the new parameter included.

Usage is as with any other configurable value:

$config->setCaCertPath('/absolute/path/to/cacert/dir'); 
$config->setCaCertFileName('cacert.pem');              // default is 'cacert.pem'
Please update the wiki: https://github.com/mpay24/mpay24-php/wiki/Configuring-the-php-sdk