### PR TITLE
Implement DeleteProfile support

### DIFF
--- a/src/Mpay24.php
+++ b/src/Mpay24.php
@@ -287,6 +287,23 @@ class Mpay24
         return $createCustomerRes;
     }
 
+    /**
+     * Delete a profile.
+     *
+     * @param string      $customerId
+     * @param string|null $profileId
+     *
+     * @return Responses\DeleteProfileResponse
+     */
+    public function deleteProfile($customerId, $profileId = null)
+    {
+        $this->integrityCheck();
+
+        $response = $this->mpay24Sdk->deleteProfile($customerId, $profileId);
+        $this->recordedLastMessageExchange('DeleteProfile');
+        return $response;
+    }
+
     protected function integrityCheck()
     {
         if (!$this->mpay24Sdk) {

--- a/src/Mpay24Sdk.php
+++ b/src/Mpay24Sdk.php
@@ -14,6 +14,7 @@ use Mpay24\Requests\SelectPayment;
 use Mpay24\Requests\TransactionHistory;
 use Mpay24\Requests\TransactionStatus;
 use Mpay24\Requests\CreateCustomer;
+use Mpay24\Requests\DeleteProfile;
 use Mpay24\Responses\AcceptPaymentResponse;
 use Mpay24\Responses\CreatePaymentTokenResponse;
 use Mpay24\Responses\ListPaymentMethodsResponse;
@@ -26,6 +27,7 @@ use Mpay24\Responses\SelectPaymentResponse;
 use Mpay24\Responses\TransactionHistoryResponse;
 use Mpay24\Responses\TransactionStatusResponse;
 use Mpay24\Responses\CreateCustomerResponse;
+use Mpay24\Responses\DeleteProfileResponse;
 
 /**
  * Main Mpay24 PHP APIs Class.
@@ -618,6 +620,27 @@ class Mpay24Sdk
 
         $result = new CreateCustomerResponse($this->response);
 
+        return $result;
+    }
+
+    /**
+     * Deletes a profile.
+     *
+     * @param string      $customerId
+     * @param string|null $profileId
+     *
+     * @return DeleteProfileResponse
+     */
+    public function deleteProfile($customerId, $profileId = null)
+    {
+        $request = new DeleteProfile($this->config->getMerchantId());
+        $request->setCustomerId($customerId);
+        $request->setProfileId($profileId);
+
+        $this->request = $request->getXml();
+        $this->send();
+
+        $result = new DeleteProfileResponse($this->response);
         return $result;
     }
 

--- a/src/Requests/DeleteProfile.php
+++ b/src/Requests/DeleteProfile.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Mpay24\Requests;
+
+/**
+ * The DeleteProfile class creates the body for the SOAP request.
+ *
+ * Class DeleteProfile
+ * @package    Mpay24\Request
+ *
+ * @author     mPAY24 GmbH <support@mpay24.com>
+ * @filesource DeleteProfile.php
+ * @license    MIT
+ */
+class DeleteProfile extends AbstractRequest
+{
+    /**
+     * @var string
+     */
+    protected $customerId;
+
+    /**
+     * @var string
+     */
+    protected $profileId;
+
+    /**
+     * @param string $customerId
+     */
+    public function setCustomerId($customerId)
+    {
+        $this->customerId = $customerId;
+    }
+
+    /**
+     * @param string $profileId
+     */
+    public function setProfileId($profileId)
+    {
+        $this->profileId = $profileId;
+    }
+
+    /**
+     * Build the request document body.
+     */
+    protected function build()
+    {
+        $operation = $this->buildOperation('DeleteProfile');
+
+        $merchantID = $this->document->createElement(
+            'merchantID',
+            $this->merchantId
+        );
+        $operation->appendChild($merchantID);
+
+        $customerId = $this->document->createElement(
+            'customerID',
+            $this->customerId
+        );
+        $operation->appendChild($customerId);
+
+        if ($this->profileId) {
+            $profileId = $this->document->createElement(
+                'profileID',
+                $this->profileId
+            );
+            $operation->appendChild($profileId);
+        }
+    }
+}

--- a/src/Responses/DeleteProfileResponse.php
+++ b/src/Responses/DeleteProfileResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mpay24\Responses;
+
+/**
+ * An API response to a request to delete payment profiles.
+ *
+ * Class DeleteProfileResponse
+ * @package    Mpay24\Responses
+ *
+ * @author     mPAY24 GmbH <support@mpay24.com>
+ * @filesource DeleteProfileResponse.php
+ * @license    MIT
+ */
+class DeleteProfileResponse extends AbstractResponse
+{
+}


### PR DESCRIPTION
Hello,

This patch implements support for DeleteProfile SOAP calls, which is currently missing from the PHP SDK. I had to implement this for a custom application and figured it would be worthwhile to upstream. Let me know if any changes are required to get this merged.

Regards,
Jeremy