### PR TITLE
Support transmission of item positions

### DIFF
--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -105,7 +105,7 @@ abstract class AbstractRequest
     {
         foreach ($list as $name => $value) {
             if (strpos($name, 'item-') === 0) {
-                $name = explode_and_trim("-", $name)[0];
+                $name = explode("-", $name)[0];
             }
             if (is_array($value)) {
                 $element = $this->document->createElement($name);

--- a/src/Requests/AbstractRequest.php
+++ b/src/Requests/AbstractRequest.php
@@ -104,6 +104,9 @@ abstract class AbstractRequest
     protected function appendArray(DOMNode &$parent, array &$list)
     {
         foreach ($list as $name => $value) {
+            if (strpos($name, 'item-') === 0) {
+                $name = explode_and_trim("-", $name)[0];
+            }
             if (is_array($value)) {
                 $element = $this->document->createElement($name);
                 $this->appendArray($element, $value);


### PR DESCRIPTION
In order to send order item information to PayPal, a nested associative array must be passed to the payment provider (cf. https://docs.mpay24.com/docs/soap-examples#section-paysafecard):

`$mpay24->payment($paymentType, $paymentInfo->getInternalPaymentId(),
                $payment, $additional);`

The additional array looks as follows:
```
Array
(
    [order] => Array
        (
            [description] => mpay24.general.orderDescription
            [shoppingCart] => Array
                (
                   Array(
                    [item] => Array
                        (
                            [productNr] => 33
                            [description] => Schlagbohrmaschine
                            [quantity] => 1
                            [tax] => 0
                            [amount] => 1234
                        )
                   )
                   Array(
                    [item] => Array
                        (
                            [productNr] => shipping
                            [descrption] => shipping
                            [quantity] => 1
                            [tax] => 0
                            [amount] => 10000
                        )
                    )
                )

        )
    [language] => de
)
```

With this configuration the XML serialization fails in Mpay24 because of the empty array keys (duplicate "item" keys in PHP are not allowed).

We used the following workaround:
```
Array
(
    [order] => Array
        (
            [description] => mpay24.general.orderDescription
            [shoppingCart] => Array
                (
                    [item-1] => Array
                        (
                            [productNr] => 33
                            [description] => Schlagbohrmaschine
                            [quantity] => 1
                            [tax] => 0
                            [amount] => 1234
                        )
                    [item-2] => Array
                        (
                            [productNr] => shipping
                            [descrption] => shipping
                            [quantity] => 1
                            [tax] => 0
                            [amount] => 10000
                        )
                    )
        )
)
```

The current position is added to each item-key and the name of the XML element ("item") is extracted in AbstractRequest.php.

Please confirm this pull request or update the PHP SDK otherwise.