### PR TITLE
List customers with profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/composer.lock
 /.idea
 /.buildpath
 /.settings
@@ -5,3 +6,4 @@
 .DS_STORE
 *.log
 /nbproject/
+/vendor

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /.idea
 /.buildpath
 /.settings
-/tests
 .DS_STORE
 *.log
 /nbproject/

--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,8 @@
     "php": ">=5.3.3",
     "ext-curl": "*",
     "ext-dom": "*"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^7.2"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,11 @@
       "Mpay24\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Mpay24Test\\": "test/"
+    }
+  },
   "require": {
     "php": ">=5.3.3",
     "ext-curl": "*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="mpay24-php">
+            <directory>./test</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
          colors="true">
     <testsuites>
         <testsuite name="mpay24-php">
-            <directory>./test</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Responses/ListProfilesResponse.php
+++ b/src/Responses/ListProfilesResponse.php
@@ -22,7 +22,7 @@ class ListProfilesResponse extends AbstractResponse
     /**
      * @var array
      */
-    protected $profiles = [];
+    protected $profiles = array();
 
     /**
      * @var int
@@ -113,8 +113,38 @@ class ListProfilesResponse extends AbstractResponse
 
                 if ($profile->getElementsByTagName('payment')->length) {
                     $this->profiles[$i]['payment'] = $profile->getElementsByTagName('payment')->item(0)->nodeValue;
+                    $this->profiles[$i]['paymentProfiles'] = $this->parsePaymentProfiles($profile->getElementsByTagName('payment'));
                 }
             }
         }
+    }
+
+    /**
+     * @param \DOMNodeList $paymentNodeList
+     * @return array
+     */
+    private function parsePaymentProfiles(\DOMNodeList $paymentNodeList)
+    {
+        $data = array();
+        foreach ($paymentNodeList as $paymentNode) {
+            $data[] = $this->parseSinglePaymentProfile($paymentNode);
+        }
+        return $data;
+    }
+
+    /**
+     * @param \DOMElement $paymentNode
+     * @return array
+     */
+    private function parseSinglePaymentProfile(\DOMElement $paymentNode)
+    {
+        $data = array();
+        /** @var \DOMElement $childNode */
+        foreach ($paymentNode->childNodes as $childNode) {
+            if ($childNode instanceof \DOMElement) {
+                $data[$childNode->nodeName] = trim($childNode->textContent);
+            }
+        }
+        return $data;
     }
 }

--- a/tests/Responses/ListProfilesResponseTest.php
+++ b/tests/Responses/ListProfilesResponseTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Mpay24Test\Responses;
+
+
+use Mpay24\Responses\ListProfilesResponse;
+use PHPUnit\Framework\TestCase;
+
+class ListProfilesResponseTest extends TestCase
+{
+    public function testConstructSingleCustomerWithNoPaymentProfiles()
+    {
+        $response = new ListProfilesResponse(file_get_contents(__DIR__.'/_files/list-profiles.response.no-payment-profiles.xml'));
+
+        $this->assertSame(1, $response->getProfileCount());
+        $this->assertSame(1, $response->getTotalNumber());
+
+        $expectedProfiles = array(
+            array(
+                'customerID' => '1234',
+                'updated' => '2018-06-05T10:54:02Z',
+            ),
+        );
+
+        $this->assertSame($expectedProfiles, $response->getProfiles());
+        $this->assertSame($expectedProfiles[0], $response->getProfile(0));
+    }
+
+    public function testConstructSingleCustomerWithPaymentProfiles()
+    {
+        $response = new ListProfilesResponse(file_get_contents(__DIR__.'/_files/list-profiles.response.with-payment-profiles.xml'));
+
+        $this->assertSame(1, $response->getProfileCount());
+        $this->assertSame(1, $response->getTotalNumber());
+
+        $profile = $response->getProfile(0);
+
+        $this->assertSame('1234', $profile['customerID']);
+        $this->assertSame('2018-06-05T10:54:02Z', $profile['updated']);
+
+        $this->assertContains('2018-06-01T12:05:08Z', $profile['payment']);
+        $this->assertContains('************1111', $profile['payment']);
+        $this->assertContains('2025-05-01', $profile['payment']);
+
+        $this->assertCount(2, $profile['paymentProfiles']);
+
+        $expectedPaymentProfiles = array(
+            array(
+                'pMethodID' => '5',
+                'profileID' => '',
+                'updated' => '2018-06-01T12:05:08Z',
+                'identifier' => '************1111',
+                'expires' => '2025-05-01',
+            ),
+            array(
+                'pMethodID' => '5',
+                'profileID' => 'testprofile3',
+                'updated' => '2018-07-02T12:45:35Z',
+                'identifier' => '************1234',
+                'expires' => '2026-06-02',
+            ),
+        );
+
+        $this->assertSame($expectedPaymentProfiles, $profile['paymentProfiles']);
+
+    }
+}

--- a/tests/Responses/_files/list-profiles.response.no-payment-profiles.xml
+++ b/tests/Responses/_files/list-profiles.response.no-payment-profiles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+                   xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:etp="https://www.mpay24.com/soap/etp/1.5/ETP.wsdl">
+    <SOAP-ENV:Body>
+        <etp:ListProfilesResponse>
+            <status>OK</status>
+            <returnCode>OK</returnCode>
+            <profile>
+                <customerID>1234</customerID>
+                <updated>2018-06-05T10:54:02Z</updated>
+            </profile>
+            <all>1</all>
+        </etp:ListProfilesResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/tests/Responses/_files/list-profiles.response.with-payment-profiles.xml
+++ b/tests/Responses/_files/list-profiles.response.with-payment-profiles.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+                   xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:etp="https://www.mpay24.com/soap/etp/1.5/ETP.wsdl">
+    <SOAP-ENV:Body>
+        <etp:ListProfilesResponse>
+            <status>OK</status>
+            <returnCode>OK</returnCode>
+            <profile>
+                <customerID>1234</customerID>
+                <updated>2018-06-05T10:54:02Z</updated>
+                <payment>
+                    <pMethodID>5</pMethodID>
+                    <profileID>
+                    </profileID>
+                    <updated>2018-06-01T12:05:08Z</updated>
+                    <identifier>************1111</identifier>
+                    <expires>2025-05-01</expires>
+                </payment>
+                <payment>
+                    <pMethodID>5</pMethodID>
+                    <profileID>testprofile3</profileID>
+                    <updated>2018-07-02T12:45:35Z</updated>
+                    <identifier>************1234</identifier>
+                    <expires>2026-06-02</expires>
+                </payment>
+            </profile>
+            <all>1</all>
+        </etp:ListProfilesResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
parsing multiple payment profiles into array key *paymentProfiles* of profile-array

## Details

if a customer has multiple payment profiles with different profileIDs, only the first profile has been parsed into the array key **payment**.

This pull request doesn't change the **payment** - key but adds a new key **paymentProfile** with all profiles from ListProfilesResponse as array. Please see `list-profiles.response.no-payment-profiles.xml` and `list-profiles.response.with-payment-profiles.xml` for example responses

