### PR TITLE
create AcceptPaymentReponse with mpayTid, errNo and errText in case of error

### DIFF
--- a/src/Responses/AbstractPaymentResponse.php
+++ b/src/Responses/AbstractPaymentResponse.php
@@ -84,6 +84,9 @@ abstract class AbstractPaymentResponse extends AbstractResponse
      */
     protected function parseResponse($body)
     {
+        if (!$body instanceof \DOMElement) {
+            return;
+        }
         if ($body->getElementsByTagName('mpayTID')->length > 0) {
             $this->mpayTid = (int)$body->getElementsByTagName('mpayTID')->item(0)->nodeValue;
         }

--- a/src/Responses/AbstractResponse.php
+++ b/src/Responses/AbstractResponse.php
@@ -53,8 +53,8 @@ abstract class AbstractResponse
      */
     public function __construct($response)
     {
+        $this->responseAsDom = new DOMDocument();
         if ('' != $response) {
-            $this->responseAsDom = new DOMDocument();
 
             if (preg_match('/<title>401 Unauthorized<\/title>/', $response) == 1) {
                 $this->status     = 'ERROR';

--- a/src/Responses/AcceptPaymentResponse.php
+++ b/src/Responses/AcceptPaymentResponse.php
@@ -25,10 +25,6 @@ class AcceptPaymentResponse extends AbstractPaymentResponse
     public function __construct($response)
     {
         parent::__construct($response);
-
-        if ($this->hasNoError()) {
-
-            $this->parseResponse($this->getBody('AcceptPaymentResponse'));
-        }
+        $this->parseResponse($this->getBody('AcceptPaymentResponse'));
     }
 }

--- a/tests/Responses/AcceptPaymentResponseTest.php
+++ b/tests/Responses/AcceptPaymentResponseTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Mpay24Test\Responses;
+
+use Mpay24\Responses\AcceptPaymentResponse;
+use PHPUnit\Framework\TestCase;
+
+class AcceptPaymentResponseTest extends TestCase
+{
+    public function testConstructStatusOk()
+    {
+        $response = new AcceptPaymentResponse(file_get_contents(__DIR__.'/_files/accept-payment.response.ok.xml'));
+        $this->assertSame('OK', $response->getStatus());
+        $this->assertEquals('OK', $response->getReturnCode());
+        $this->assertSame(12345, $response->getMpayTid());
+
+        $this->assertNull($response->getErrNo());
+        $this->assertNull($response->getErrText());
+        $this->assertNull($response->getLocation());
+
+        $this->assertTrue($response->hasNoError());
+        $this->assertTrue($response->hasStatusOk());
+    }
+
+    public function testConstructStatusError()
+    {
+        $response = new AcceptPaymentResponse(file_get_contents(__DIR__.'/_files/accept-payment.response.error.xml'));
+        $this->assertSame('ERROR', $response->getStatus());
+        $this->assertEquals('EXTERNAL_ERROR', $response->getReturnCode());
+        $this->assertSame(12345, $response->getMpayTid());
+
+        $this->assertSame(100, $response->getErrNo());
+        $this->assertSame('cvv2/cvc2 falsch (cvv2/cvc2 failure)', $response->getErrText());
+        $this->assertNull($response->getLocation());
+
+        $this->assertFalse($response->hasNoError());
+        $this->assertFalse($response->hasStatusOk());
+    }
+
+    public function testConstructXmlResponseEmpty()
+    {
+        $response = new AcceptPaymentResponse('');
+        $this->assertSame('ERROR', $response->getStatus());
+        $this->assertEquals('The response is empty! Probably your request to mPAY24 was not sent! Please see your server log for more information!', $response->getReturnCode());
+        $this->assertNull($response->getMpayTid());
+
+        $this->assertNull($response->getErrNo());
+        $this->assertNull($response->getErrText());
+        $this->assertNull($response->getLocation());
+
+        $this->assertFalse($response->hasNoError());
+        $this->assertFalse($response->hasStatusOk());
+    }
+
+    public function testConstructInvalidXml()
+    {
+        $response = new AcceptPaymentResponse('<?xml version="1.0" encoding="UTF-8"?><xml>invalidxml');
+        $this->assertSame('ERROR', $response->getStatus());
+        $this->assertSame('Unknown Error', $response->getReturnCode());
+
+        $this->assertNull($response->getErrNo());
+        $this->assertNull($response->getErrText());
+        $this->assertNull($response->getLocation());
+
+        $this->assertFalse($response->hasNoError());
+        $this->assertFalse($response->hasStatusOk());
+    }
+
+    public function testConstructUnauthorized()
+    {
+        $response = new AcceptPaymentResponse(file_get_contents(__DIR__.'/_files/accept-payment.response.unauthorized.xml'));
+
+        $this->assertSame('ERROR', $response->getStatus());
+        $this->assertSame('401 Unauthorized: check your merchant ID and password', $response->getReturnCode());
+
+        $this->assertNull($response->getErrNo());
+        $this->assertNull($response->getErrText());
+        $this->assertNull($response->getLocation());
+
+        $this->assertFalse($response->hasNoError());
+        $this->assertFalse($response->hasStatusOk());
+    }
+}

--- a/tests/Responses/_files/accept-payment.response.error.xml
+++ b/tests/Responses/_files/accept-payment.response.error.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+                   xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:etp="https://www.mpay24.com/soap/etp/1.5/ETP.wsdl">
+    <SOAP-ENV:Body>
+        <etp:AcceptPaymentResponse>
+            <status>ERROR</status>
+            <returnCode>EXTERNAL_ERROR</returnCode>
+            <mpayTID>12345</mpayTID>
+            <errNo>100</errNo>
+            <errText>cvv2/cvc2 falsch (cvv2/cvc2 failure)</errText>
+        </etp:AcceptPaymentResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/tests/Responses/_files/accept-payment.response.ok.xml
+++ b/tests/Responses/_files/accept-payment.response.ok.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+                   xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:etp="https://www.mpay24.com/soap/etp/1.5/ETP.wsdl">
+    <SOAP-ENV:Body>
+        <etp:AcceptPaymentResponse>
+            <status>OK</status>
+            <returnCode>OK</returnCode>
+            <mpayTID>12345</mpayTID>
+        </etp:AcceptPaymentResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/tests/Responses/_files/accept-payment.response.unauthorized.xml
+++ b/tests/Responses/_files/accept-payment.response.unauthorized.xml
@@ -1,0 +1,16 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html>
+    <head>
+        <title>401 Unauthorized</title>
+    </head>
+    <body>
+        <h1>Unauthorized</h1>
+        <p>This server could not verify that you
+            are authorized to access the document
+            requested. Either you supplied the wrong
+            credentials (e.g., bad password), or your
+            browser doesn't understand how to supply
+            the credentials required.
+        </p>
+    </body>
+</html>


### PR DESCRIPTION
## Details

### Old behaviour

`Mpay24\Responses\AbstractPaymentResponse::parseResponse` isn't called, if response status is  **ERROR**. So mpayTID, errNo, and errText are **null** and it isn't possible to get detail information what caused the error.

### New behaviour

`Mpay24\Responses\AbstractPaymentResponse::parseResponse` is called if payment error occured, too. So especially errNo and errText are available, so it's possible to provide detail information what caused the payment error.