### PR TITLE
Parse create customer error details

### DIFF
--- a/src/Responses/CreateCustomerResponse.php
+++ b/src/Responses/CreateCustomerResponse.php
@@ -25,9 +25,6 @@ class CreateCustomerResponse extends AbstractPaymentResponse
     public function __construct($response)
     {
         parent::__construct($response);
-
-        if ($this->hasNoError()) {
-            $this->parseResponse($this->getBody('CreateCustomerResponse'));
-        }
+        $this->parseResponse($this->getBody('CreateCustomerResponse'));
     }
 }

--- a/tests/Responses/CreateCustomerResponseTest.php
+++ b/tests/Responses/CreateCustomerResponseTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Mpay24Test\Responses;
+
+use Mpay24\Responses\CreateCustomerResponse;
+use PHPUnit\Framework\TestCase;
+
+class CreateCustomerResponseTest extends TestCase
+{
+    public function testConstructStatusOk()
+    {
+        $response = new CreateCustomerResponse(file_get_contents(__DIR__.'/_files/create-customer.response.ok.xml'));
+        $this->assertSame('OK', $response->getStatus());
+        $this->assertEquals('PROFILE_CREATED', $response->getReturnCode());
+        $this->assertNull($response->getMpayTid());
+
+        $this->assertNull($response->getErrNo());
+        $this->assertNull($response->getErrText());
+        $this->assertNull($response->getLocation());
+
+        $this->assertTrue($response->hasNoError());
+        $this->assertTrue($response->hasStatusOk());
+    }
+
+    public function testConstructStatusError()
+    {
+        $response = new CreateCustomerResponse(file_get_contents(__DIR__.'/_files/create-customer.response.error.xml'));
+        $this->assertSame('ERROR', $response->getStatus());
+        $this->assertEquals('PROFILEID_NOT_CORRECT', $response->getReturnCode());
+        $this->assertNull($response->getMpayTid());
+
+        $this->assertSame(7, $response->getErrNo());
+        $this->assertNull($response->getErrText());
+        $this->assertNull($response->getLocation());
+
+        $this->assertFalse($response->hasNoError());
+        $this->assertFalse($response->hasStatusOk());
+    }
+}

--- a/tests/Responses/_files/create-customer.response.error.xml
+++ b/tests/Responses/_files/create-customer.response.error.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+                   xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:etp="https://www.mpay24.com/soap/etp/1.5/ETP.wsdl">
+    <SOAP-ENV:Body>
+        <etp:CreateCustomerResponse>
+            <status>ERROR</status>
+            <returnCode>PROFILEID_NOT_CORRECT</returnCode>
+            <errNo>7</errNo>
+        </etp:CreateCustomerResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/tests/Responses/_files/create-customer.response.ok.xml
+++ b/tests/Responses/_files/create-customer.response.ok.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+                   xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                   xmlns:etp="https://www.mpay24.com/soap/etp/1.5/ETP.wsdl">
+    <SOAP-ENV:Body>
+        <etp:CreateCustomerResponse>
+            <status>OK</status>
+            <returnCode>PROFILE_CREATED</returnCode>
+        </etp:CreateCustomerResponse>
+    </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>


### PR DESCRIPTION
soap-xml-response hasn't been parsed correctly, so `errNo` of `Mpay24\Responses\CreateCustomerResponse` was empty. PR fixes parsing.