### PR TITLE
Escape XML Entities, detect if already escaped

### DIFF
--- a/src/Mpay24Order.php
+++ b/src/Mpay24Order.php
@@ -152,15 +152,15 @@ class Mpay24Order
             $value = $this->formatDecimal($value);
         }
 
-        if (strpos($value, "<") || strpos($value, ">")) {
-            $value = "<![CDATA[" . $this->xmlEncode($value) . "]]>";
-        }
-
         if ($query->length > 0) {
-            $query->item(0)->nodeValue = $value;
+            $query->item(0)->textContent = $value;
         } else {
-            $node       = $this->document->createElement($name, $value);
-            $this->node = $this->node->appendChild($node);
+            $element = $this->document->createElement($name);
+            if (!empty($value)) {
+                $txtnode = $this->document->createTextNode($value);
+                $element->appendChild($txtnode);
+            }
+            $this->node = $this->node->appendChild($element);
         }
     }
 
@@ -171,24 +171,6 @@ class Mpay24Order
     public function toXML()
     {
         return $this->document->saveXML();
-    }
-
-    /**
-     * Encode the XML-characters in a string
-     *
-     * @param string $txt A string to be encoded
-     *
-     * @return string
-     */
-    protected function xmlEncode($txt)
-    {
-        $txt = str_replace('&', '&amp;', $txt);
-        $txt = str_replace('<', '&lt;', $txt);
-        $txt = str_replace('>', '&gt;', $txt);
-        $txt = str_replace('&apos;', "'", $txt);
-        $txt = str_replace('&quot;', '"', $txt);
-
-        return $txt;
     }
 
     /**

--- a/src/Mpay24Order.php
+++ b/src/Mpay24Order.php
@@ -101,7 +101,7 @@ class Mpay24Order
                         $value = $this->formatDecimal($value);
                     }
 
-                    $node = $this->document->createElement($method, $value);
+                    $node = $this->createTextElement($method, $value);
                 } else {
                     $node = $this->document->createElement($method);
                 }
@@ -155,11 +155,7 @@ class Mpay24Order
         if ($query->length > 0) {
             $query->item(0)->textContent = $value;
         } else {
-            $element = $this->document->createElement($name);
-            if (!empty($value)) {
-                $txtnode = $this->document->createTextNode($value);
-                $element->appendChild($txtnode);
-            }
+            $element = $this->createTextElement($name,$value);
             $this->node = $this->node->appendChild($element);
         }
     }
@@ -186,6 +182,28 @@ class Mpay24Order
             default:
                 return false;
         }
+    }
+
+    /**
+     * @param string $name
+     * @param string $value
+     *
+     * @return DOMElement element created
+     */
+    protected function createTextElement($name, $value)
+    {
+        $encoded = htmlentities($value, ENT_XML1, "UTF-8", false); // detect if already encoded
+
+        if ($value === $encoded) { // already encoded
+            return $this->document->createElement($name, $value);
+        }
+
+        $element = $this->document->createElement($name);
+        if (!empty($value)) {
+            $txtnode = $this->document->createTextNode($value);
+            $element->appendChild($txtnode);
+        }
+        return $element;
     }
 
     /**

--- a/src/Mpay24Order.php
+++ b/src/Mpay24Order.php
@@ -153,7 +153,11 @@ class Mpay24Order
         }
 
         if ($query->length > 0) {
-            $query->item(0)->textContent = $value;
+            if ($this->isAlreadyXMLEncoded($value)) {
+                $query->item(0)->nodeValue = $value;
+            } else {
+                $query->item(0)->textContent = $value;
+            }
         } else {
             $element = $this->createTextElement($name,$value);
             $this->node = $this->node->appendChild($element);
@@ -192,18 +196,26 @@ class Mpay24Order
      */
     protected function createTextElement($name, $value)
     {
-        $encoded = htmlentities($value, ENT_XML1, "UTF-8", false); // detect if already encoded
-
-        if ($value === $encoded) { // already encoded
+        if ($this->isAlreadyXMLEncoded($value)) {
             return $this->document->createElement($name, $value);
         }
-
         $element = $this->document->createElement($name);
         if (!empty($value)) {
             $txtnode = $this->document->createTextNode($value);
             $element->appendChild($txtnode);
         }
         return $element;
+    }
+
+    /**
+     * @param string $source
+     *
+     * @return boolean
+     */
+    protected function isAlreadyXMLEncoded($source)
+    {
+        $encoded = htmlentities($source, ENT_XML1, "UTF-8", false); // detect if already encoded
+        return ($source === $encoded); // already encoded
     }
 
     /**

--- a/tests/Mpay24OrderTest.php
+++ b/tests/Mpay24OrderTest.php
@@ -46,6 +46,7 @@ class Mpay24OrderTest extends TestCase
         $mdxi = new Mpay24Order();
         $mdxi->Order->setLogoStyle("");
 
+        $mdxi->Order->UserField = "My User Field&apos;&quot;&lt;&amp;&gt;";
         $mdxi->Order->Tid       = "My Transaction ID'\"<&>";
 
         $mdxi->Order->TemplateSet->setLanguage("DE");
@@ -98,6 +99,7 @@ class Mpay24OrderTest extends TestCase
 
         $this->assertSame('<?xml version="1.0" encoding="UTF-8"?>', $xml[0]);
         $this->assertSame('<Order LogoStyle="">', $xml[1]);
+        $this->assertSame('<UserField>My User Field\'"&lt;&amp;&gt;</UserField>', $xml[2]);
         $this->assertSame('<Tid>My Transaction ID\'"&lt;&amp;&gt;</Tid>', $xml[3]);
         $this->assertSame('<TemplateSet Language="DE" CSSName="MODERN"/>', $xml[4]);
         $this->assertSame('<PaymentTypes Enable="true">', $xml[5]);

--- a/tests/Mpay24OrderTest.php
+++ b/tests/Mpay24OrderTest.php
@@ -46,8 +46,7 @@ class Mpay24OrderTest extends TestCase
         $mdxi = new Mpay24Order();
         $mdxi->Order->setLogoStyle("");
 
-        $mdxi->Order->UserField = "My User Field";
-        $mdxi->Order->Tid       = "My Transaction ID";
+        $mdxi->Order->Tid       = "My Transaction ID'\"<&>";
 
         $mdxi->Order->TemplateSet->setLanguage("DE");
         $mdxi->Order->TemplateSet->setCSSName("MODERN");
@@ -81,7 +80,7 @@ class Mpay24OrderTest extends TestCase
         $mdxi->Order->Currency = "USD";
 
         $mdxi->Order->Customer->setUseProfile("true");
-        $mdxi->Order->Customer->setId("98765");
+        $mdxi->Order->Customer->setId("98765'\"<&>");
         $mdxi->Order->Customer = "Hans Mayer";
 
         $mdxi->Order->BillingAddr->setMode("ReadOnly");
@@ -99,8 +98,7 @@ class Mpay24OrderTest extends TestCase
 
         $this->assertSame('<?xml version="1.0" encoding="UTF-8"?>', $xml[0]);
         $this->assertSame('<Order LogoStyle="">', $xml[1]);
-        $this->assertSame('<UserField>My User Field</UserField>', $xml[2]);
-        $this->assertSame('<Tid>My Transaction ID</Tid>', $xml[3]);
+        $this->assertSame('<Tid>My Transaction ID\'"&lt;&amp;&gt;</Tid>', $xml[3]);
         $this->assertSame('<TemplateSet Language="DE" CSSName="MODERN"/>', $xml[4]);
         $this->assertSame('<PaymentTypes Enable="true">', $xml[5]);
         $this->assertSame('<Payment Type="CC" Brand="VISA"/>', $xml[6]);
@@ -128,7 +126,7 @@ class Mpay24OrderTest extends TestCase
         $this->assertSame('</ShoppingCart>', $xml[28]);
         $this->assertSame('<Price>30.35</Price>', $xml[29]);
         $this->assertSame('<Currency>USD</Currency>', $xml[30]);
-        $this->assertSame('<Customer UseProfile="true" Id="98765">Hans Mayer</Customer>', $xml[31]);
+        $this->assertSame('<Customer UseProfile="true" Id="98765\'&quot;&lt;&amp;&gt;">Hans Mayer</Customer>', $xml[31]);
         $this->assertSame('<BillingAddr Mode="ReadOnly">', $xml[32]);
         $this->assertSame('<Name>Max Musterman</Name>', $xml[33]);
         $this->assertSame('<Street>Teststreet 1</Street>', $xml[34]);

--- a/tests/Mpay24OrderTest.php
+++ b/tests/Mpay24OrderTest.php
@@ -93,6 +93,10 @@ class Mpay24OrderTest extends TestCase
         $mdxi->Order->BillingAddr->Country->setCode("AT");
         $mdxi->Order->BillingAddr->Email = "a.b@c.de";
 
+        // overwrite adding entities
+        $mdxi->Order->BillingAddr->Name = "Max Musterman'\"<&>";
+        $mdxi->Order->BillingAddr->Street = "Teststreet 1&apos;&quot;&lt;&amp;&gt;";
+
         $xml = array_map('trim', explode("\n", $mdxi->toXML()));
 
         $this->assertGreaterThanOrEqual(42, count($xml));
@@ -130,8 +134,8 @@ class Mpay24OrderTest extends TestCase
         $this->assertSame('<Currency>USD</Currency>', $xml[30]);
         $this->assertSame('<Customer UseProfile="true" Id="98765\'&quot;&lt;&amp;&gt;">Hans Mayer</Customer>', $xml[31]);
         $this->assertSame('<BillingAddr Mode="ReadOnly">', $xml[32]);
-        $this->assertSame('<Name>Max Musterman</Name>', $xml[33]);
-        $this->assertSame('<Street>Teststreet 1</Street>', $xml[34]);
+        $this->assertSame('<Name>Max Musterman\'"&lt;&amp;&gt;</Name>', $xml[33]);
+        $this->assertSame('<Street>Teststreet 1\'"&lt;&amp;&gt;</Street>', $xml[34]);
         $this->assertSame('<Street2>Teststreet 2</Street2>', $xml[35]);
         $this->assertSame('<Zip>1010</Zip>', $xml[36]);
         $this->assertSame('<City>Wien</City>', $xml[37]);


### PR DESCRIPTION
We will try to support both escaped and unescaped xml entities:
```
$mdxi->Order->TID = '< & >';
$mdxi->Order->UserField = '&lt;&amp;&gt;';
```